### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "connectgateway",
     "name_pretty": "GKE Connect Gateway API",
     "product_documentation": "https://cloud.google.com/anthos/multicluster-management/gateway",
-    "client_documentation": "https://googleapis.dev/python/connectgateway/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/connectgateway/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.