### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "connectgateway",
     "name_pretty": "GKE Connect Gateway API",
     "product_documentation": "https://cloud.google.com/anthos/multicluster-management/gateway",
-    "client_documentation": "https://googleapis.dev/python/connectgateway/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/connectgateway/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ automate DevOps processes across all your clusters.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-gke-connect-gateway.svg
    :target: https://pypi.org/project/google-cloud-gke-connect-gateway/
 .. _GKE Connect Gateway: https://cloud.google.com/anthos/multicluster-management/gateway/
-.. _Client Library Documentation: https://googleapis.dev/python/connectgateway/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/connectgateway/latest
 .. _Product Documentation:  https://cloud.google.com/anthos/multicluster-management/gateway/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.