### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [0.5.1](https://github.com/googleapis/python-gke-connect-gateway/compare/v0.5.0...v0.5.1) (2022-03-05)
+## [0.5.1](https://github.com/googleapis/python-gke-connect-gateway/compare/v0.5.0...v0.5.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -24,7 +24,7 @@
 
 * add generated snippets ([#70](https://github.com/googleapis/python-gke-connect-gateway/issues/70)) ([011d98d](https://github.com/googleapis/python-gke-connect-gateway/commit/011d98d0b206c62728d3279c01ca79fe1527d0ee))
 
-### [0.4.1](https://www.github.com/googleapis/python-gke-connect-gateway/compare/v0.4.0...v0.4.1) (2021-11-01)
+## [0.4.1](https://www.github.com/googleapis/python-gke-connect-gateway/compare/v0.4.0...v0.4.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -56,14 +56,14 @@
 
 * add context manager support in client ([#40](https://www.github.com/googleapis/python-gke-connect-gateway/issues/40)) ([862692a](https://www.github.com/googleapis/python-gke-connect-gateway/commit/862692a5685744827c49fa68d7375ad04cdf63b0))
 
-### [0.2.3](https://www.github.com/googleapis/python-gke-connect-gateway/compare/v0.2.2...v0.2.3) (2021-09-24)
+## [0.2.3](https://www.github.com/googleapis/python-gke-connect-gateway/compare/v0.2.2...v0.2.3) (2021-09-24)
 
 
 ### Bug Fixes
 
 * add 'dict' annotation type to 'request' ([f23d221](https://www.github.com/googleapis/python-gke-connect-gateway/commit/f23d221f3d8abab4ba9265daa49bb8b691d887c5))
 
-### [0.2.2](https://www.github.com/googleapis/python-gke-connect-gateway/compare/v0.2.1...v0.2.2) (2021-07-29)
+## [0.2.2](https://www.github.com/googleapis/python-gke-connect-gateway/compare/v0.2.1...v0.2.2) (2021-07-29)
 
 
 ### Bug Fixes
@@ -80,7 +80,7 @@
 
 * release as 0.2.2 ([#20](https://www.github.com/googleapis/python-gke-connect-gateway/issues/20)) ([6494fae](https://www.github.com/googleapis/python-gke-connect-gateway/commit/6494fae2a5fe3e1d1472048fb889c78a520764eb))
 
-### [0.2.1](https://www.github.com/googleapis/python-gke-connect-gateway/compare/v0.2.0...v0.2.1) (2021-07-21)
+## [0.2.1](https://www.github.com/googleapis/python-gke-connect-gateway/compare/v0.2.0...v0.2.1) (2021-07-21)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.